### PR TITLE
fix: throttle RGB updates to protect bus timing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ void RGB_update()
 
     static uint32_t last = 0u;
 
-    uint32_t min_gap = time_hw_tpms;
+    uint32_t min_gap = time_hw_tpms * 10u;
     if (!min_gap) min_gap = 1u;
 
     const uint32_t now = time_ticks32();


### PR DESCRIPTION
Restore the RGB update throttle from ~1ms to ~10ms.

V10.3 introduced the faster 1ms RGB update cadence. This does not appear to affect all BMCU hardware, but on affected units it can prevent filament color/type changes from being saved reliably.

WS2812 writes disable IRQs, and the 1ms cadence introduced in V10.3 can interfere with Bambu bus packet timing. Hardware testing showed the 10ms `RGB_update()` cadence passes while the 1ms RGB rate fails.

May address:
- #104
- #97
- #126

Validation:
- `pio run -e ams_a_010`: SUCCESS